### PR TITLE
Add S9 leaderboards

### DIFF
--- a/src/apis/embarkApi.ts
+++ b/src/apis/embarkApi.ts
@@ -1,12 +1,12 @@
 import type { ZodSchema } from "zod";
 import { orfSchema } from "../schemas/leaderboards/orf";
 import { season9Schema } from "../schemas/leaderboards/season9";
-import { season9SponsorSchema } from "../schemas/leaderboards/season9Sponsor";
 import { season9CashoutSchema } from "../schemas/leaderboards/season9Cashout";
-import { season9QuickCashSchema } from "../schemas/leaderboards/season9QuickCash";
+import { season9Head2HeadSchema } from "../schemas/leaderboards/season9Head2Head";
 import { season9PointBreakSchema } from "../schemas/leaderboards/season9PointBreak";
 import { season9PowerShiftSchema } from "../schemas/leaderboards/season9PowerShift";
-import { season9Head2HeadSchema } from "../schemas/leaderboards/season9Head2Head";
+import { season9QuickCashSchema } from "../schemas/leaderboards/season9QuickCash";
+import { season9SponsorSchema } from "../schemas/leaderboards/season9Sponsor";
 import { season9TeamDeathmatchSchema } from "../schemas/leaderboards/season9TeamDeathmatch";
 import type { BaseUser } from "../types";
 

--- a/src/apis/embarkApi.ts
+++ b/src/apis/embarkApi.ts
@@ -1,13 +1,13 @@
 import type { ZodSchema } from "zod";
 import { orfSchema } from "../schemas/leaderboards/orf";
 import { season9Schema } from "../schemas/leaderboards/season9";
-import { season9CashoutSchema } from "../schemas/leaderboards/season9Cashout";
 import { season9Head2HeadSchema } from "../schemas/leaderboards/season9Head2Head";
 import { season9PointBreakSchema } from "../schemas/leaderboards/season9PointBreak";
 import { season9PowerShiftSchema } from "../schemas/leaderboards/season9PowerShift";
 import { season9QuickCashSchema } from "../schemas/leaderboards/season9QuickCash";
 import { season9SponsorSchema } from "../schemas/leaderboards/season9Sponsor";
 import { season9TeamDeathmatchSchema } from "../schemas/leaderboards/season9TeamDeathmatch";
+import { season9WorldTourSchema } from "../schemas/leaderboards/season9WorldTour";
 import type { BaseUser } from "../types";
 
 export type EmbarkApi = {
@@ -25,9 +25,9 @@ export const embarkApi = {
     url: "https://id.embark.games/the-finals/leaderboards/s9s",
     zodSchema: season9SponsorSchema,
   },
-  season9Cashout: {
+  season9WorldTour: {
     url: "https://id.embark.games/the-finals/leaderboards/s9wt",
-    zodSchema: season9CashoutSchema,
+    zodSchema: season9WorldTourSchema,
   },
   season9Head2Head: {
     url: "https://id.embark.games/the-finals/leaderboards/s9h2h",

--- a/src/apis/embarkApi.ts
+++ b/src/apis/embarkApi.ts
@@ -1,13 +1,13 @@
 import type { ZodSchema } from "zod";
 import { orfSchema } from "../schemas/leaderboards/orf";
-import { season8Schema } from "../schemas/leaderboards/season8";
-import { season8BlastOffSchema } from "../schemas/leaderboards/season8BlastOff";
-import { season8Head2HeadSchema } from "../schemas/leaderboards/season8Head2Head";
-import { season8PowerShiftSchema } from "../schemas/leaderboards/season8PowerShift";
-import { season8QuickCashSchema } from "../schemas/leaderboards/season8QuickCash";
-import { season8SponsorSchema } from "../schemas/leaderboards/season8Sponsor";
-import { season8TeamDeathmatchSchema } from "../schemas/leaderboards/season8TeamDeathmatch";
-import { season8WorldTourSchema } from "../schemas/leaderboards/season8WorldTour";
+import { season9Schema } from "../schemas/leaderboards/season9";
+import { season9SponsorSchema } from "../schemas/leaderboards/season9Sponsor";
+import { season9CashoutSchema } from "../schemas/leaderboards/season9Cashout";
+import { season9QuickCashSchema } from "../schemas/leaderboards/season9QuickCash";
+import { season9PointBreakSchema } from "../schemas/leaderboards/season9PointBreak";
+import { season9PowerShiftSchema } from "../schemas/leaderboards/season9PowerShift";
+import { season9Head2HeadSchema } from "../schemas/leaderboards/season9Head2Head";
+import { season9TeamDeathmatchSchema } from "../schemas/leaderboards/season9TeamDeathmatch";
 import type { BaseUser } from "../types";
 
 export type EmbarkApi = {
@@ -17,37 +17,37 @@ export type EmbarkApi = {
 
 /** `embarkApi` lists the URL and Zod schema used to validate and transform the response for a leaderboard. */
 export const embarkApi = {
-  season8: {
-    url: "https://id.embark.games/the-finals/leaderboards/s8",
-    zodSchema: season8Schema,
+  season9: {
+    url: "https://id.embark.games/the-finals/leaderboards/s9",
+    zodSchema: season9Schema,
   },
-  season8Sponsor: {
-    url: "https://id.embark.games/the-finals/leaderboards/s8s",
-    zodSchema: season8SponsorSchema,
+  season9Sponsor: {
+    url: "https://id.embark.games/the-finals/leaderboards/s9s",
+    zodSchema: season9SponsorSchema,
   },
-  season8WorldTour: {
-    url: "https://id.embark.games/the-finals/leaderboards/s8wt",
-    zodSchema: season8WorldTourSchema,
+  season9Cashout: {
+    url: "https://id.embark.games/the-finals/leaderboards/s9wt",
+    zodSchema: season9CashoutSchema,
   },
-  season8Head2Head: {
-    url: "https://id.embark.games/the-finals/leaderboards/s8h2h",
-    zodSchema: season8Head2HeadSchema,
+  season9Head2Head: {
+    url: "https://id.embark.games/the-finals/leaderboards/s9h2h",
+    zodSchema: season9Head2HeadSchema,
   },
-  season8PowerShift: {
-    url: "https://id.embark.games/the-finals/leaderboards/s8ps",
-    zodSchema: season8PowerShiftSchema,
+  season9PowerShift: {
+    url: "https://id.embark.games/the-finals/leaderboards/s9ps",
+    zodSchema: season9PowerShiftSchema,
   },
-  season8QuickCash: {
-    url: "https://id.embark.games/the-finals/leaderboards/s8qc",
-    zodSchema: season8QuickCashSchema,
+  season9QuickCash: {
+    url: "https://id.embark.games/the-finals/leaderboards/s9qc",
+    zodSchema: season9QuickCashSchema,
   },
-  season8TeamDeathmatch: {
-    url: "https://id.embark.games/the-finals/leaderboards/s8tdm",
-    zodSchema: season8TeamDeathmatchSchema,
+  season9TeamDeathmatch: {
+    url: "https://id.embark.games/the-finals/leaderboards/s9tdm",
+    zodSchema: season9TeamDeathmatchSchema,
   },
-  season8BlastOff: {
-    url: "https://id.embark.games/the-finals/leaderboards/s8bo",
-    zodSchema: season8BlastOffSchema,
+  season9PointBreak: {
+    url: "https://id.embark.games/the-finals/leaderboards/s9pb",
+    zodSchema: season9PointBreakSchema,
   },
 
   orf: {

--- a/src/apis/leaderboard.ts
+++ b/src/apis/leaderboard.ts
@@ -43,6 +43,14 @@ import { season8QuickCashUserSchema } from "../schemas/leaderboards/season8Quick
 import { season8SponsorUserSchema } from "../schemas/leaderboards/season8Sponsor";
 import { season8TeamDeathmatchUserSchema } from "../schemas/leaderboards/season8TeamDeathmatch";
 import { season8WorldTourUserSchema } from "../schemas/leaderboards/season8WorldTour";
+import { season9UserSchema } from "../schemas/leaderboards/season9";
+import { season9Head2HeadUserSchema } from "../schemas/leaderboards/season9Head2Head";
+import { season9PowerShiftUserSchema } from "../schemas/leaderboards/season9PowerShift";
+import { season9QuickCashUserSchema } from "../schemas/leaderboards/season9QuickCash";
+import { season9SponsorUserSchema } from "../schemas/leaderboards/season9Sponsor";
+import { season9TeamDeathmatchUserSchema } from "../schemas/leaderboards/season9TeamDeathmatch";
+import { season9CashoutUserSchema } from "../schemas/leaderboards/season9Cashout";
+import { season9PointBreakUserSchema } from "../schemas/leaderboards/season9PointBreak";
 import { theFinalsUserSchema } from "../schemas/leaderboards/theFinals";
 import type { BaseAPIRoute, LeaderboardPlatforms } from "../types";
 import { fetchWithKVFallback } from "../utils/fetchWithKVFallback";
@@ -490,118 +498,94 @@ export const leaderboardApiRoutes: BaseAPIRoute[] = [
   }),
 
   // SEASON 8
-  createLiveLeaderboard(
-    {
-      id: "s8",
-      availablePlatforms: ["crossplay"],
-      hasClubData: true,
-      metadata: {
-        summary: "Season 8",
-        description: "Get leaderboard data from the eighth season of THE FINALS.",
-        tags: ["Leaderboards"],
-      },
-      zodSchemaOpenApi: season8UserSchema,
+  createOldLeaderboard({
+    id: "s8",
+    availablePlatforms: ["crossplay"],
+    hasClubData: true,
+    metadata: {
+      summary: "Season 8",
+      description: "Get leaderboard data from the eighth season of THE FINALS.",
+      tags: ["Leaderboards"],
     },
-    embarkApi.season8,
-  ),
-  createLiveLeaderboard(
-    {
-      id: "s8sponsor",
-      availablePlatforms: ["crossplay"],
-      hasClubData: true,
-      metadata: {
-        summary: "Season 8 Sponsor",
-        description: "Get leaderboard data from the eighth season of THE FINALS - Sponsor.",
-        tags: ["Leaderboards"],
-      },
-      zodSchemaOpenApi: season8SponsorUserSchema,
+    zodSchemaOpenApi: season8UserSchema,
+  }),
+  createOldLeaderboard({
+    id: "s8sponsor",
+    availablePlatforms: ["crossplay"],
+    hasClubData: true,
+    metadata: {
+      summary: "Season 8 Sponsor",
+      description: "Get leaderboard data from the eighth season of THE FINALS - Sponsor.",
+      tags: ["Leaderboards"],
     },
-    embarkApi.season8Sponsor,
-  ),
-  createLiveLeaderboard(
-    {
-      id: "s8worldtour",
-      availablePlatforms: ["crossplay"],
-      hasClubData: true,
-      metadata: {
-        summary: "Season 8 World Tour",
-        description: "Get leaderboard data from the eighth season of THE FINALS - World Tour.",
-        tags: ["Leaderboards"],
-      },
-      zodSchemaOpenApi: season8WorldTourUserSchema,
+    zodSchemaOpenApi: season8SponsorUserSchema,
+  }),
+  createOldLeaderboard({
+    id: "s8worldtour",
+    availablePlatforms: ["crossplay"],
+    hasClubData: true,
+    metadata: {
+      summary: "Season 8 World Tour",
+      description: "Get leaderboard data from the eighth season of THE FINALS - World Tour.",
+      tags: ["Leaderboards"],
     },
-    embarkApi.season8WorldTour,
-  ),
-  createLiveLeaderboard(
-    {
-      id: "s8head2head",
-      availablePlatforms: ["crossplay"],
-      hasClubData: true,
-      metadata: {
-        summary: "Season 8 Head2Head",
-        description: "Get leaderboard data from the eighth season of THE FINALS - Head2Head.",
-        tags: ["Leaderboards"],
-      },
-      zodSchemaOpenApi: season8Head2HeadUserSchema,
+    zodSchemaOpenApi: season8WorldTourUserSchema,
+  }),
+  createOldLeaderboard({
+    id: "s8head2head",
+    availablePlatforms: ["crossplay"],
+    hasClubData: true,
+    metadata: {
+      summary: "Season 8 Head2Head",
+      description: "Get leaderboard data from the eighth season of THE FINALS - Head2Head.",
+      tags: ["Leaderboards"],
     },
-    embarkApi.season8Head2Head,
-  ),
-  createLiveLeaderboard(
-    {
-      id: "s8powershift",
-      availablePlatforms: ["crossplay"],
-      hasClubData: true,
-      metadata: {
-        summary: "Season 8 PowerShift",
-        description: "Get leaderboard data from the eighth season of THE FINALS - PowerShift.",
-        tags: ["Leaderboards"],
-      },
-      zodSchemaOpenApi: season8PowerShiftUserSchema,
+    zodSchemaOpenApi: season8Head2HeadUserSchema,
+  }),
+  createOldLeaderboard({
+    id: "s8powershift",
+    availablePlatforms: ["crossplay"],
+    hasClubData: true,
+    metadata: {
+      summary: "Season 8 PowerShift",
+      description: "Get leaderboard data from the eighth season of THE FINALS - PowerShift.",
+      tags: ["Leaderboards"],
     },
-    embarkApi.season8PowerShift,
-  ),
-  createLiveLeaderboard(
-    {
-      id: "s8quickcash",
-      availablePlatforms: ["crossplay"],
-      hasClubData: true,
-      metadata: {
-        summary: "Season 8 Quick Cash",
-        description: "Get leaderboard data from the eighth season of THE FINALS - Quick Cash.",
-        tags: ["Leaderboards"],
-      },
-      zodSchemaOpenApi: season8QuickCashUserSchema,
+    zodSchemaOpenApi: season8PowerShiftUserSchema,
+  }),
+  createOldLeaderboard({
+    id: "s8quickcash",
+    availablePlatforms: ["crossplay"],
+    hasClubData: true,
+    metadata: {
+      summary: "Season 8 Quick Cash",
+      description: "Get leaderboard data from the eighth season of THE FINALS - Quick Cash.",
+      tags: ["Leaderboards"],
     },
-    embarkApi.season8QuickCash,
-  ),
-  createLiveLeaderboard(
-    {
-      id: "s8teamdeathmatch",
-      availablePlatforms: ["crossplay"],
-      hasClubData: true,
-      metadata: {
-        summary: "Season 8 Team Deathmatch",
-        description: "Get leaderboard data from the eighth season of THE FINALS - Team Deathmatch.",
-        tags: ["Leaderboards"],
-      },
-      zodSchemaOpenApi: season8TeamDeathmatchUserSchema,
+    zodSchemaOpenApi: season8QuickCashUserSchema,
+  }),
+  createOldLeaderboard({
+    id: "s8teamdeathmatch",
+    availablePlatforms: ["crossplay"],
+    hasClubData: true,
+    metadata: {
+      summary: "Season 8 Team Deathmatch",
+      description: "Get leaderboard data from the eighth season of THE FINALS - Team Deathmatch.",
+      tags: ["Leaderboards"],
     },
-    embarkApi.season8TeamDeathmatch,
-  ),
-  createLiveLeaderboard(
-    {
-      id: "s8blastoff",
-      availablePlatforms: ["crossplay"],
-      hasClubData: true,
-      metadata: {
-        summary: "Season 8 Blast Off",
-        description: "Get leaderboard data from the eighth season of THE FINALS - Blast Off.",
-        tags: ["Leaderboards"],
-      },
-      zodSchemaOpenApi: season8BlastOffUserSchema,
+    zodSchemaOpenApi: season8TeamDeathmatchUserSchema,
+  }),
+  createOldLeaderboard({
+    id: "s8blastoff",
+    availablePlatforms: ["crossplay"],
+    hasClubData: true,
+    metadata: {
+      summary: "Season 8 Blast Off",
+      description: "Get leaderboard data from the eighth season of THE FINALS - Blast Off.",
+      tags: ["Leaderboards"],
     },
-    embarkApi.season8BlastOff,
-  ),
+    zodSchemaOpenApi: season8BlastOffUserSchema,
+  }),
   createOldLeaderboard({
     id: "s8ghoulrush",
     availablePlatforms: ["crossplay"],
@@ -624,6 +608,120 @@ export const leaderboardApiRoutes: BaseAPIRoute[] = [
     },
     zodSchemaOpenApi: season8HeavenOrElseUserSchema,
   }),
+
+  // SEASON 9
+  createLiveLeaderboard(
+    {
+      id: "s9",
+      availablePlatforms: ["crossplay"],
+      hasClubData: true,
+      metadata: {
+        summary: "Season 9",
+        description: "Get leaderboard data from the ninth season of THE FINALS.",
+        tags: ["Leaderboards"],
+      },
+      zodSchemaOpenApi: season9UserSchema,
+    },
+    embarkApi.season9,
+  ),
+  createLiveLeaderboard(
+    {
+      id: "s9sponsor",
+      availablePlatforms: ["crossplay"],
+      hasClubData: true,
+      metadata: {
+        summary: "Season 9 Sponsor",
+        description: "Get leaderboard data from the ninth season of THE FINALS - Sponsor.",
+        tags: ["Leaderboards"],
+      },
+      zodSchemaOpenApi: season9SponsorUserSchema,
+    },
+    embarkApi.season9Sponsor,
+  ),
+  createLiveLeaderboard(
+    {
+      id: "s9cashout", // formerly World Tour
+      availablePlatforms: ["crossplay"],
+      hasClubData: true,
+      metadata: {
+        summary: "Season 9 Cashout (formerly World Tour)",
+        description: "Get leaderboard data from the ninth season of THE FINALS - Cashout (formerly World Tour).",
+        tags: ["Leaderboards"],
+      },
+      zodSchemaOpenApi: season9CashoutUserSchema,
+    },
+    embarkApi.season9Cashout,
+  ),
+  createLiveLeaderboard(
+    {
+      id: "s9head2head",
+      availablePlatforms: ["crossplay"],
+      hasClubData: true,
+      metadata: {
+        summary: "Season 9 Head2Head",
+        description: "Get leaderboard data from the ninth season of THE FINALS - Head2Head.",
+        tags: ["Leaderboards"],
+      },
+      zodSchemaOpenApi: season9Head2HeadUserSchema,
+    },
+    embarkApi.season9Head2Head,
+  ),
+  createLiveLeaderboard(
+    {
+      id: "s9powershift",
+      availablePlatforms: ["crossplay"],
+      hasClubData: true,
+      metadata: {
+        summary: "Season 9 PowerShift",
+        description: "Get leaderboard data from the ninth season of THE FINALS - PowerShift.",
+        tags: ["Leaderboards"],
+      },
+      zodSchemaOpenApi: season9PowerShiftUserSchema,
+    },
+    embarkApi.season9PowerShift,
+  ),
+  createLiveLeaderboard(
+    {
+      id: "s9quickcash",
+      availablePlatforms: ["crossplay"],
+      hasClubData: true,
+      metadata: {
+        summary: "Season 9 Quick Cash",
+        description: "Get leaderboard data from the ninth season of THE FINALS - Quick Cash.",
+        tags: ["Leaderboards"],
+      },
+      zodSchemaOpenApi: season9QuickCashUserSchema,
+    },
+    embarkApi.season9QuickCash,
+  ),
+  createLiveLeaderboard(
+    {
+      id: "s9teamdeathmatch",
+      availablePlatforms: ["crossplay"],
+      hasClubData: true,
+      metadata: {
+        summary: "Season 9 Team Deathmatch",
+        description: "Get leaderboard data from the ninth season of THE FINALS - Team Deathmatch.",
+        tags: ["Leaderboards"],
+      },
+      zodSchemaOpenApi: season9TeamDeathmatchUserSchema,
+    },
+    embarkApi.season9TeamDeathmatch,
+  ),
+  createLiveLeaderboard(
+    {
+      id: "s9pointbreak",
+      availablePlatforms: ["crossplay"],
+      hasClubData: true,
+      metadata: {
+        summary: "Season 9 Point Break",
+        description: "Get leaderboard data from the ninth season of THE FINALS - Point Break.",
+        tags: ["Leaderboards"],
+      },
+      zodSchemaOpenApi: season9PointBreakUserSchema,
+    },
+    embarkApi.season9PointBreak,
+  ),
 
   // Special leaderboards not tied to a season
   createOldLeaderboard({

--- a/src/apis/leaderboard.ts
+++ b/src/apis/leaderboard.ts
@@ -644,7 +644,7 @@ export const leaderboardApiRoutes: BaseAPIRoute[] = [
       availablePlatforms: ["crossplay"],
       hasClubData: true,
       metadata: {
-        summary: "Season 9 Cashout (formerly World Tour)",
+        summary: "Season 9 Cashout",
         description: "Get leaderboard data from the ninth season of THE FINALS - Cashout (formerly World Tour).",
         tags: ["Leaderboards"],
       },

--- a/src/apis/leaderboard.ts
+++ b/src/apis/leaderboard.ts
@@ -44,13 +44,13 @@ import { season8SponsorUserSchema } from "../schemas/leaderboards/season8Sponsor
 import { season8TeamDeathmatchUserSchema } from "../schemas/leaderboards/season8TeamDeathmatch";
 import { season8WorldTourUserSchema } from "../schemas/leaderboards/season8WorldTour";
 import { season9UserSchema } from "../schemas/leaderboards/season9";
-import { season9CashoutUserSchema } from "../schemas/leaderboards/season9Cashout";
 import { season9Head2HeadUserSchema } from "../schemas/leaderboards/season9Head2Head";
 import { season9PointBreakUserSchema } from "../schemas/leaderboards/season9PointBreak";
 import { season9PowerShiftUserSchema } from "../schemas/leaderboards/season9PowerShift";
 import { season9QuickCashUserSchema } from "../schemas/leaderboards/season9QuickCash";
 import { season9SponsorUserSchema } from "../schemas/leaderboards/season9Sponsor";
 import { season9TeamDeathmatchUserSchema } from "../schemas/leaderboards/season9TeamDeathmatch";
+import { season9WorldTourUserSchema } from "../schemas/leaderboards/season9WorldTour";
 import { theFinalsUserSchema } from "../schemas/leaderboards/theFinals";
 import type { BaseAPIRoute, LeaderboardPlatforms } from "../types";
 import { fetchWithKVFallback } from "../utils/fetchWithKVFallback";
@@ -640,17 +640,17 @@ export const leaderboardApiRoutes: BaseAPIRoute[] = [
   ),
   createLiveLeaderboard(
     {
-      id: "s9cashout", // formerly World Tour
+      id: "s9worldtour",
       availablePlatforms: ["crossplay"],
       hasClubData: true,
       metadata: {
-        summary: "Season 9 Cashout",
-        description: "Get leaderboard data from the ninth season of THE FINALS - Cashout (formerly World Tour).",
+        summary: "Season 9 World Tour",
+        description: "Get leaderboard data from the ninth season of THE FINALS - World Tour.",
         tags: ["Leaderboards"],
       },
-      zodSchemaOpenApi: season9CashoutUserSchema,
+      zodSchemaOpenApi: season9WorldTourUserSchema,
     },
-    embarkApi.season9Cashout,
+    embarkApi.season9WorldTour,
   ),
   createLiveLeaderboard(
     {

--- a/src/apis/leaderboard.ts
+++ b/src/apis/leaderboard.ts
@@ -44,13 +44,13 @@ import { season8SponsorUserSchema } from "../schemas/leaderboards/season8Sponsor
 import { season8TeamDeathmatchUserSchema } from "../schemas/leaderboards/season8TeamDeathmatch";
 import { season8WorldTourUserSchema } from "../schemas/leaderboards/season8WorldTour";
 import { season9UserSchema } from "../schemas/leaderboards/season9";
+import { season9CashoutUserSchema } from "../schemas/leaderboards/season9Cashout";
 import { season9Head2HeadUserSchema } from "../schemas/leaderboards/season9Head2Head";
+import { season9PointBreakUserSchema } from "../schemas/leaderboards/season9PointBreak";
 import { season9PowerShiftUserSchema } from "../schemas/leaderboards/season9PowerShift";
 import { season9QuickCashUserSchema } from "../schemas/leaderboards/season9QuickCash";
 import { season9SponsorUserSchema } from "../schemas/leaderboards/season9Sponsor";
 import { season9TeamDeathmatchUserSchema } from "../schemas/leaderboards/season9TeamDeathmatch";
-import { season9CashoutUserSchema } from "../schemas/leaderboards/season9Cashout";
-import { season9PointBreakUserSchema } from "../schemas/leaderboards/season9PointBreak";
 import { theFinalsUserSchema } from "../schemas/leaderboards/theFinals";
 import type { BaseAPIRoute, LeaderboardPlatforms } from "../types";
 import { fetchWithKVFallback } from "../utils/fetchWithKVFallback";

--- a/src/schemas/leaderboards/season9.ts
+++ b/src/schemas/leaderboards/season9.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import leagueNumberToName from "../../utils/leagueNumberToName";
+import nameFallback from "../../utils/nameFallback";
+import {
+  changePropertySchema,
+  clubTagPropertySchema,
+  leagueNumberPropertySchema,
+  leaguePropertySchema,
+  namePropertySchema,
+  psnNamePropertySchema,
+  rankPropertySchema,
+  rankScorePropertySchema,
+  steamNamePropertySchema,
+  xboxNamePropertySchema,
+} from "../userProperties";
+
+export const season9Schema = z
+  .object({
+    1: z.number(),
+    // 25-01-21: The 24h change (2) can now comeback as an empty string. Treat it as a 0 in the transform.
+    2: z.union([z.number(), z.string()]),
+    // For some reason, the name can come back as a 0 (number) instead of a string. Example: {"1":4059,"2":57070,"3":0,"4":11,"5":25114,"6":"ඞ ⁧ AK","7":0,"8":0}
+    3: z.union([z.string(), z.number()]),
+    4: z.number(),
+    5: z.number(),
+    6: z.union([z.string(), z.number()]).optional(),
+    7: z.union([z.string(), z.number()]).optional(),
+    8: z.union([z.string(), z.number()]).optional(),
+    12: z.union([z.string(), z.number()]).optional(),
+  })
+  .transform((data) => ({
+    rank: data[1],
+    change: typeof data[2] !== "number" ? 0 : data[2],
+    name: nameFallback(data[3], "Unknown#0000"),
+    steamName: nameFallback(data[6]),
+    psnName: nameFallback(data[7]),
+    xboxName: nameFallback(data[8]),
+    clubTag: nameFallback(data[12]),
+    leagueNumber: data[4],
+    league: leagueNumberToName(data[4]),
+    rankScore: data[5],
+  }))
+  .array();
+
+// This is passed to the OpenAPI spec
+export const season9UserSchema = z
+  .object({
+    rank: rankPropertySchema,
+    change: changePropertySchema,
+    name: namePropertySchema,
+    steamName: steamNamePropertySchema,
+    psnName: psnNamePropertySchema,
+    xboxName: xboxNamePropertySchema,
+    clubTag: clubTagPropertySchema,
+    leagueNumber: leagueNumberPropertySchema,
+    league: leaguePropertySchema,
+    rankScore: rankScorePropertySchema,
+  })
+  .openapi("Season9User", {
+    title: "Season 9 User",
+    description: "A user in the Season 9 leaderboard.",
+  }) satisfies z.ZodType<z.infer<typeof season9Schema>[number]>;

--- a/src/schemas/leaderboards/season9Cashout.ts
+++ b/src/schemas/leaderboards/season9Cashout.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import nameFallback from "../../utils/nameFallback";
+import {
+  cashoutsPropertySchema,
+  clubTagPropertySchema,
+  namePropertySchema,
+  psnNamePropertySchema,
+  rankPropertySchema,
+  steamNamePropertySchema,
+  xboxNamePropertySchema,
+} from "../userProperties";
+
+export const season9CashoutSchema = z
+  .object({
+    1: z.number(),
+    // For some reason, the name can come back as a 0 (number) instead of a string. Example: {"1":4059,"2":57070,"3":0,"4":11,"5":25114,"6":"ඞ ⁧ AK","7":0,"8":0}
+    // 25-01-11: One instance of 3 coming back as undefined. Only in this leaderboard so far.
+    3: z.union([z.string(), z.number()]).optional(),
+    5: z.number(),
+    6: z.union([z.string(), z.number()]).optional(),
+    7: z.union([z.string(), z.number()]).optional(),
+    8: z.union([z.string(), z.number()]).optional(),
+    12: z.union([z.string(), z.number()]).optional(),
+  })
+  .transform((data) => ({
+    rank: data[1],
+    name: nameFallback(data[3], "Unknown#0000"),
+    steamName: nameFallback(data[6]),
+    psnName: nameFallback(data[7]),
+    xboxName: nameFallback(data[8]),
+    clubTag: nameFallback(data[12]),
+    cashouts: data[5],
+  }))
+  .array();
+
+// This is passed to the OpenAPI spec
+export const season9CashoutUserSchema = z
+  .object({
+    rank: rankPropertySchema,
+    name: namePropertySchema,
+    steamName: steamNamePropertySchema,
+    psnName: psnNamePropertySchema,
+    xboxName: xboxNamePropertySchema,
+    clubTag: clubTagPropertySchema,
+    cashouts: cashoutsPropertySchema,
+  })
+  .openapi("Season9CashoutUser", {
+    title: "Season 9 Cashout User",
+    description: "A user in the Season 9 Cashout leaderboard.",
+  }) satisfies z.ZodType<z.infer<typeof season9CashoutSchema>[number]>;

--- a/src/schemas/leaderboards/season9Head2Head.ts
+++ b/src/schemas/leaderboards/season9Head2Head.ts
@@ -33,7 +33,7 @@ export const season9Head2HeadSchema = z
   .array();
 
 // This is passed to the OpenAPI spec
-export const season9Head2HeadUserSchema= z
+export const season9Head2HeadUserSchema = z
   .object({
     rank: rankPropertySchema,
     name: namePropertySchema,

--- a/src/schemas/leaderboards/season9Head2Head.ts
+++ b/src/schemas/leaderboards/season9Head2Head.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import nameFallback from "../../utils/nameFallback";
+import {
+  clubTagPropertySchema,
+  namePropertySchema,
+  psnNamePropertySchema,
+  rankPropertySchema,
+  scorePropertySchema,
+  steamNamePropertySchema,
+  xboxNamePropertySchema,
+} from "../userProperties";
+
+export const season9Head2HeadSchema = z
+  .object({
+    1: z.number(),
+    // For some reason, the name can come back as a 0 (number) instead of a string. Example: {"1":4059,"2":57070,"3":0,"4":11,"5":25114,"6":"ඞ ⁧ AK","7":0,"8":0}
+    3: z.union([z.string(), z.number()]),
+    5: z.number(),
+    6: z.union([z.string(), z.number()]).optional(),
+    7: z.union([z.string(), z.number()]).optional(),
+    8: z.union([z.string(), z.number()]).optional(),
+    12: z.union([z.string(), z.number()]).optional(),
+  })
+  .transform((data) => ({
+    rank: data[1],
+    name: nameFallback(data[3], "Unknown#0000"),
+    steamName: nameFallback(data[6]),
+    psnName: nameFallback(data[7]),
+    xboxName: nameFallback(data[8]),
+    clubTag: nameFallback(data[12]),
+    points: data[5],
+  }))
+  .array();
+
+// This is passed to the OpenAPI spec
+export const season9Head2HeadUserSchema= z
+  .object({
+    rank: rankPropertySchema,
+    name: namePropertySchema,
+    steamName: steamNamePropertySchema,
+    psnName: psnNamePropertySchema,
+    xboxName: xboxNamePropertySchema,
+    clubTag: clubTagPropertySchema,
+    points: scorePropertySchema,
+  })
+  .openapi("Season9Head2HeadUser", {
+    title: "Season 9 Head2Head User",
+    description: "A user in the Season 9 Head2Head leaderboard.",
+  }) satisfies z.ZodType<z.infer<typeof season9Head2HeadSchema>[number]>;

--- a/src/schemas/leaderboards/season9PointBreak.ts
+++ b/src/schemas/leaderboards/season9PointBreak.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import nameFallback from "../../utils/nameFallback";
+import {
+  clubTagPropertySchema,
+  namePropertySchema,
+  psnNamePropertySchema,
+  rankPropertySchema,
+  scorePropertySchema,
+  steamNamePropertySchema,
+  xboxNamePropertySchema,
+} from "../userProperties";
+
+export const season9PointBreakSchema = z
+  .object({
+    1: z.number(),
+    // For some reason, the name can come back as a 0 (number) instead of a string. Example: {"1":4059,"2":57070,"3":0,"4":11,"5":25114,"6":"ඞ ⁧ AK","7":0,"8":0}
+    3: z.union([z.string(), z.number()]),
+    5: z.number(),
+    6: z.union([z.string(), z.number()]).optional(),
+    7: z.union([z.string(), z.number()]).optional(),
+    8: z.union([z.string(), z.number()]).optional(),
+    12: z.union([z.string(), z.number()]).optional(),
+  })
+  .transform((data) => ({
+    rank: data[1],
+    name: nameFallback(data[3], "Unknown#0000"),
+    steamName: nameFallback(data[6]),
+    psnName: nameFallback(data[7]),
+    xboxName: nameFallback(data[8]),
+    clubTag: nameFallback(data[12]),
+    points: data[5],
+  }))
+  .array();
+
+// This is passed to the OpenAPI spec
+export const season9PointBreakUserSchema = z
+  .object({
+    rank: rankPropertySchema,
+    name: namePropertySchema,
+    steamName: steamNamePropertySchema,
+    psnName: psnNamePropertySchema,
+    xboxName: xboxNamePropertySchema,
+    clubTag: clubTagPropertySchema,
+    points: scorePropertySchema,
+  })
+  .openapi("Season9PointBreakUser", {
+    title: "Season 9 Point Break User",
+    description: "A user in the Season 9 Point Break leaderboard.",
+  }) satisfies z.ZodType<z.infer<typeof season9PointBreakSchema>[number]>;

--- a/src/schemas/leaderboards/season9PowerShift.ts
+++ b/src/schemas/leaderboards/season9PowerShift.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import nameFallback from "../../utils/nameFallback";
+import {
+  clubTagPropertySchema,
+  namePropertySchema,
+  psnNamePropertySchema,
+  rankPropertySchema,
+  scorePropertySchema,
+  steamNamePropertySchema,
+  xboxNamePropertySchema,
+} from "../userProperties";
+
+export const season9PowerShiftSchema = z
+  .object({
+    1: z.number(),
+    // For some reason, the name can come back as a 0 (number) instead of a string. Example: {"1":4059,"2":57070,"3":0,"4":11,"5":25114,"6":"ඞ ⁧ AK","7":0,"8":0}
+    3: z.union([z.string(), z.number()]),
+    5: z.number(),
+    6: z.union([z.string(), z.number()]).optional(),
+    7: z.union([z.string(), z.number()]).optional(),
+    8: z.union([z.string(), z.number()]).optional(),
+    12: z.union([z.string(), z.number()]).optional(),
+  })
+  .transform((data) => ({
+    rank: data[1],
+    name: nameFallback(data[3], "Unknown#0000"),
+    steamName: nameFallback(data[6]),
+    psnName: nameFallback(data[7]),
+    xboxName: nameFallback(data[8]),
+    clubTag: nameFallback(data[12]),
+    points: data[5],
+  }))
+  .array();
+
+// This is passed to the OpenAPI spec
+export const season9PowerShiftUserSchema = z
+  .object({
+    rank: rankPropertySchema,
+    name: namePropertySchema,
+    steamName: steamNamePropertySchema,
+    psnName: psnNamePropertySchema,
+    xboxName: xboxNamePropertySchema,
+    clubTag: clubTagPropertySchema,
+    points: scorePropertySchema,
+  })
+  .openapi("Season9PowerShiftUser", {
+    title: "Season 9 PowerShift User",
+    description: "A user in the Season 9 PowerShift leaderboard.",
+  }) satisfies z.ZodType<z.infer<typeof season9PowerShiftSchema>[number]>;

--- a/src/schemas/leaderboards/season9QuickCash.ts
+++ b/src/schemas/leaderboards/season9QuickCash.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import nameFallback from "../../utils/nameFallback";
+import {
+  clubTagPropertySchema,
+  namePropertySchema,
+  psnNamePropertySchema,
+  rankPropertySchema,
+  scorePropertySchema,
+  steamNamePropertySchema,
+  xboxNamePropertySchema,
+} from "../userProperties";
+
+export const season9QuickCashSchema = z
+  .object({
+    1: z.number(),
+    // For some reason, the name can come back as a 0 (number) instead of a string. Example: {"1":4059,"2":57070,"3":0,"4":11,"5":25114,"6":"ඞ ⁧ AK","7":0,"8":0}
+    3: z.union([z.string(), z.number()]),
+    5: z.number(),
+    6: z.union([z.string(), z.number()]).optional(),
+    7: z.union([z.string(), z.number()]).optional(),
+    8: z.union([z.string(), z.number()]).optional(),
+    12: z.union([z.string(), z.number()]).optional(),
+  })
+  .transform((data) => ({
+    rank: data[1],
+    name: nameFallback(data[3], "Unknown#0000"),
+    steamName: nameFallback(data[6]),
+    psnName: nameFallback(data[7]),
+    xboxName: nameFallback(data[8]),
+    clubTag: nameFallback(data[12]),
+    points: data[5],
+  }))
+  .array();
+
+// This is passed to the OpenAPI spec
+export const season9QuickCashUserSchema = z
+  .object({
+    rank: rankPropertySchema,
+    name: namePropertySchema,
+    steamName: steamNamePropertySchema,
+    psnName: psnNamePropertySchema,
+    xboxName: xboxNamePropertySchema,
+    clubTag: clubTagPropertySchema,
+    points: scorePropertySchema,
+  })
+  .openapi("Season9QuickCashUser", {
+    title: "Season 9 Quick Qash User",
+    description: "A user in the Season 9 Quick Qash leaderboard.",
+  }) satisfies z.ZodType<z.infer<typeof season9QuickCashSchema>[number]>;

--- a/src/schemas/leaderboards/season9Sponsor.ts
+++ b/src/schemas/leaderboards/season9Sponsor.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import nameFallback from "../../utils/nameFallback";
+import {
+  clubTagPropertySchema,
+  fansPropertySchema,
+  namePropertySchema,
+  psnNamePropertySchema,
+  rankPropertySchema,
+  sponsorPropertySchema,
+  steamNamePropertySchema,
+  xboxNamePropertySchema,
+} from "../userProperties";
+
+export const season9SponsorSchema = z
+  .object({
+    1: z.number(),
+    // For some reason, the name can come back as a 0 (number) instead of a string. Example: {"1":4059,"2":57070,"3":0,"4":11,"5":25114,"6":"ඞ ⁧ AK","7":0,"8":0}
+    3: z.union([z.string(), z.number()]),
+    6: z.union([z.string(), z.number()]).optional(),
+    7: z.union([z.string(), z.number()]).optional(),
+    8: z.union([z.string(), z.number()]).optional(),
+    9: z.string(),
+    10: z.number(),
+    12: z.union([z.string(), z.number()]).optional(),
+  })
+  .transform((data) => ({
+    rank: data[1],
+    name: nameFallback(data[3], "Unknown#0000"),
+    steamName: nameFallback(data[6]),
+    psnName: nameFallback(data[7]),
+    xboxName: nameFallback(data[8]),
+    clubTag: nameFallback(data[12]),
+    sponsor: data[9],
+    fans: data[10],
+  }))
+  .array();
+
+// This is passed to the OpenAPI spec
+export const season9SponsorUserSchema = z
+  .object({
+    rank: rankPropertySchema,
+    name: namePropertySchema,
+    steamName: steamNamePropertySchema,
+    psnName: psnNamePropertySchema,
+    xboxName: xboxNamePropertySchema,
+    clubTag: clubTagPropertySchema,
+    sponsor: sponsorPropertySchema,
+    fans: fansPropertySchema,
+  })
+  .openapi("Season9SponsorUser", {
+    title: "Season 9 Sponsor User",
+    description: "A user in the Season 9 Sponsor leaderboard.",
+  }) satisfies z.ZodType<z.infer<typeof season9SponsorSchema>[number]>;

--- a/src/schemas/leaderboards/season9TeamDeathmatch.ts
+++ b/src/schemas/leaderboards/season9TeamDeathmatch.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import nameFallback from "../../utils/nameFallback";
+import {
+  clubTagPropertySchema,
+  namePropertySchema,
+  psnNamePropertySchema,
+  rankPropertySchema,
+  scorePropertySchema,
+  steamNamePropertySchema,
+  xboxNamePropertySchema,
+} from "../userProperties";
+
+export const season9TeamDeathmatchSchema = z
+  .object({
+    1: z.number(),
+    // For some reason, the name can come back as a 0 (number) instead of a string. Example: {"1":4059,"2":57070,"3":0,"4":11,"5":25114,"6":"ඞ ⁧ AK","7":0,"8":0}
+    3: z.union([z.string(), z.number()]),
+    5: z.number(),
+    6: z.union([z.string(), z.number()]).optional(),
+    7: z.union([z.string(), z.number()]).optional(),
+    8: z.union([z.string(), z.number()]).optional(),
+    12: z.union([z.string(), z.number()]).optional(),
+  })
+  .transform((data) => ({
+    rank: data[1],
+    name: nameFallback(data[3], "Unknown#0000"),
+    steamName: nameFallback(data[6]),
+    psnName: nameFallback(data[7]),
+    xboxName: nameFallback(data[8]),
+    clubTag: nameFallback(data[12]),
+    points: data[5],
+  }))
+  .array();
+
+// This is passed to the OpenAPI spec
+export const season9TeamDeathmatchUserSchema = z
+  .object({
+    rank: rankPropertySchema,
+    name: namePropertySchema,
+    steamName: steamNamePropertySchema,
+    psnName: psnNamePropertySchema,
+    xboxName: xboxNamePropertySchema,
+    clubTag: clubTagPropertySchema,
+    points: scorePropertySchema,
+  })
+  .openapi("Season9TeamDeathmatchUser", {
+    title: "Season 9 Team Deathmatch User",
+    description: "A user in the Season 9 Team Deathmatch leaderboard.",
+  }) satisfies z.ZodType<z.infer<typeof season9TeamDeathmatchSchema>[number]>;

--- a/src/schemas/leaderboards/season9WorldTour.ts
+++ b/src/schemas/leaderboards/season9WorldTour.ts
@@ -10,7 +10,7 @@ import {
   xboxNamePropertySchema,
 } from "../userProperties";
 
-export const season9CashoutSchema = z
+export const season9WorldTourSchema = z
   .object({
     1: z.number(),
     // For some reason, the name can come back as a 0 (number) instead of a string. Example: {"1":4059,"2":57070,"3":0,"4":11,"5":25114,"6":"ඞ ⁧ AK","7":0,"8":0}
@@ -34,7 +34,7 @@ export const season9CashoutSchema = z
   .array();
 
 // This is passed to the OpenAPI spec
-export const season9CashoutUserSchema = z
+export const season9WorldTourUserSchema = z
   .object({
     rank: rankPropertySchema,
     name: namePropertySchema,
@@ -44,7 +44,7 @@ export const season9CashoutUserSchema = z
     clubTag: clubTagPropertySchema,
     cashouts: cashoutsPropertySchema,
   })
-  .openapi("Season9CashoutUser", {
-    title: "Season 9 Cashout User",
-    description: "A user in the Season 9 Cashout leaderboard.",
-  }) satisfies z.ZodType<z.infer<typeof season9CashoutSchema>[number]>;
+  .openapi("Season9WorldTourUser", {
+    title: "Season 9 World Tour User",
+    description: "A user in the Season 9 World Tour leaderboard.",
+  }) satisfies z.ZodType<z.infer<typeof season9WorldTourSchema>[number]>;


### PR DESCRIPTION
This PR:
- adds S9 leaderboard schemas, including the new Point Break gamemode
- S9 World Tour uses "Cashout" name, to better reflect the in-game name
- turns S8 leaderboards into "old" ones